### PR TITLE
docs: add pollenjp to LICENSE as fork contributor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Mykal Machon
+Copyright (c) 2026 pollenjp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Append `Copyright (c) 2026 pollenjp` to the MIT `LICENSE` as a fork contributor.
- Preserve the original `Copyright (c) 2025 Mykal Machon` line, as required by MIT License terms.

## Rationale

This repository is a fork of an MIT-licensed project. MIT License requires that the original copyright notice be retained, but additional copyright holders may append their own notice for their contributions. This PR adds my copyright line without modifying or removing the original.

## Test plan

- [x] `LICENSE` still contains the unchanged original copyright line and full MIT license text.
- [x] Only one line is added (visual diff inspection).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PR9xatr4RDYTkXCCyP47BM)_