### PR TITLE
ci: align release workflow with op_run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,25 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: release
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
+      # Generating a GitHub token, so that PRs and tags created by
+      # the release-please-action can trigger actions workflows.
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: generate-token
         with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
- Use a GitHub App token (via `actions/create-github-app-token`) for `release-please` so PRs/tags it creates can trigger downstream workflows.
- Gate the `release-please` job on the `release` environment (already set up).
- Pin `googleapis/release-please-action` to `v5.0.0` and the token action to `v3` by commit SHA, matching `pollenjp/op_run`'s workflow.

## Test plan
- [ ] Confirm `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY` secrets are configured in the `release` environment.
- [ ] Merge to `main-dev` and verify release-please opens a release PR signed by the app.
- [ ] Verify tagging/release upload still works end-to-end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QimZDEpBNZxeym9joF3LWf)_