### PR TITLE
chore: add mise.toml with shfmt and shellcheck lint tasks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,9 @@
 root = true
 
-[*.{sh,bash,zsh}] # for shfmt
+[{*.{sh,bash,zsh},oprun}] # for shfmt
 indent_style = space
 indent_size = 2
 # -bn, --binary-next-line binary ops like && and | may start a line
 binary_next_line = true
-case_indent = true
-# switch_case_indent = true
+# case_indent = true
+switch_case_indent = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{sh,bash,zsh}] # for shfmt
+indent_style = space
+indent_size = 2
+# -bn, --binary-next-line binary ops like && and | may start a line
+binary_next_line = true
+case_indent = true
+# switch_case_indent = true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  shfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -15,5 +15,16 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
-      - name: Run lint
-        run: mise run lint
+      - name: Run shfmt
+        run: mise run lint:shfmt
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Run shellcheck
+        run: mise run lint:shellcheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Run lint
         run: mise run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main-dev
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+
+      - name: Run lint
+        run: mise run lint

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+enable=all

--- a/mise.toml
+++ b/mise.toml
@@ -4,11 +4,11 @@ shellcheck = "latest"
 
 [tasks."lint:shfmt"]
 description = "Check shell script formatting with shfmt"
-run = "shfmt --diff oprun"
+run = "shfmt -ci --diff oprun"
 
 [tasks."fmt:shfmt"]
 description = "Format shell scripts with shfmt"
-run = "shfmt --write oprun"
+run = "shfmt -ci --write oprun"
 
 [tasks."lint:shellcheck"]
 description = "Lint shell scripts with shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,10 @@ shellcheck = "latest"
 description = "Check shell script formatting with shfmt"
 run = "shfmt --diff oprun"
 
+[tasks."fmt:shfmt"]
+description = "Format shell scripts with shfmt"
+run = "shfmt --write oprun"
+
 [tasks."lint:shellcheck"]
 description = "Lint shell scripts with shellcheck"
 run = "shellcheck oprun"

--- a/mise.toml
+++ b/mise.toml
@@ -4,11 +4,11 @@ shellcheck = "latest"
 
 [tasks."lint:shfmt"]
 description = "Check shell script formatting with shfmt"
-run = "shfmt -ci --diff oprun"
+run = "shfmt --diff oprun"
 
 [tasks."fmt:shfmt"]
 description = "Format shell scripts with shfmt"
-run = "shfmt -ci --write oprun"
+run = "shfmt --write oprun"
 
 [tasks."lint:shellcheck"]
 description = "Lint shell scripts with shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -17,3 +17,7 @@ run = "shellcheck oprun"
 [tasks.lint]
 description = "Run all lint tasks"
 depends = ["lint:*"]
+
+[tasks.fmt]
+description = "Run all fmt tasks"
+depends = ["fmt:*"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+[tools]
+shfmt = "latest"
+shellcheck = "latest"
+
+[tasks."lint:shfmt"]
+description = "Check shell script formatting with shfmt"
+run = "shfmt --diff oprun"
+
+[tasks."lint:shellcheck"]
+description = "Lint shell scripts with shellcheck"
+run = "shellcheck oprun"
+
+[tasks.lint]
+description = "Run all lint tasks"
+depends = ["lint:*"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-shfmt = "latest"
-shellcheck = "latest"
+shfmt = "3.13.1"
+shellcheck = "0.11.0"
 
 [tasks."lint:shfmt"]
 description = "Check shell script formatting with shfmt"

--- a/oprun
+++ b/oprun
@@ -12,7 +12,7 @@
 #   oprun -e secrets.env -- python manage.py runserver
 #   oprun -h
 
-set -e
+set -euo pipefail
 
 # Default values
 ENV_FILE=".env.template"
@@ -86,39 +86,39 @@ echo_stderr() {
 VERBOSE=false
 while [[ $# -gt 0 ]]; do
 	case $1 in
-		-h | --help)
-			show_help
-			exit 0
-			;;
-		-e | --env-file)
-			ENV_FILE="$2"
-			shift 2
-			;;
-		-v | --verbose)
-			VERBOSE=true
-			shift
-			;;
-		-q | --quiet)
-			quiet_flag=1
-			shift
-			;;
-		--win-exe)
-			win_exe_flag=1
-			shift
-			;;
-		--)
-			shift
-			break
-			;;
-		-*)
-			echo_stderr "${RED}Error: Unknown option $1${NC}"
-			echo_stderr "Use -h or --help for usage information"
-			exit 1
-			;;
-		*)
-			# First non-option argument, assume it's the start of the command
-			break
-			;;
+	-h | --help)
+		show_help
+		exit 0
+		;;
+	-e | --env-file)
+		ENV_FILE="$2"
+		shift 2
+		;;
+	-v | --verbose)
+		VERBOSE=true
+		shift
+		;;
+	-q | --quiet)
+		quiet_flag=1
+		shift
+		;;
+	--win-exe)
+		win_exe_flag=1
+		shift
+		;;
+	--)
+		shift
+		break
+		;;
+	-*)
+		echo_stderr "${RED}Error: Unknown option $1${NC}"
+		echo_stderr "Use -h or --help for usage information"
+		exit 1
+		;;
+	*)
+		# First non-option argument, assume it's the start of the command
+		break
+		;;
 	esac
 done
 
@@ -130,8 +130,8 @@ if [[ $# -eq 0 ]]; then
 fi
 
 # Check if env file exists
-if [[ ! -f "$ENV_FILE" ]]; then
-	echo_stderr "${RED}Error: Env file '$ENV_FILE' not found${NC}"
+if [[ ! -f "${ENV_FILE}" ]]; then
+	echo_stderr "${RED}Error: Env file '${ENV_FILE}' not found${NC}"
 	echo_stderr "${YELLOW}Create an env file with your 1Password secret references:${NC}"
 	echo_stderr 'DATABASE_URL="op://vault-name/item-name/field-name"'
 	echo_stderr 'API_KEY="op://vault-name/item-name/password"'
@@ -140,7 +140,7 @@ fi
 
 # Check if op CLI is available, with fallback to op.exe (for WSL)
 OP_CMD="op"
-if [[ $win_exe_flag -eq 1 ]] || ! command -v op &>/dev/null; then
+if [[ ${win_exe_flag} -eq 1 ]] || ! command -v op &>/dev/null; then
 	OP_CMD="op.exe"
 	if command -v "${OP_CMD}" &>/dev/null; then
 		echo_stdout "${YELLOW}Using Windows 1Password CLI (op.exe) from WSL${NC}"
@@ -153,28 +153,28 @@ if [[ $win_exe_flag -eq 1 ]] || ! command -v op &>/dev/null; then
 fi
 
 # Check if user is signed in to 1Password
-if ! $OP_CMD account list &>/dev/null; then
+if ! ${OP_CMD} account list &>/dev/null; then
 	echo_stderr "${RED}Error: Not signed in to 1Password${NC}"
-	echo_stderr "Please run: $OP_CMD signin"
+	echo_stderr "Please run: ${OP_CMD} signin"
 	exit 1
 fi
 
-echo_stdout "${BLUE}Loading secrets from $ENV_FILE...${NC}"
+echo_stdout "${BLUE}Loading secrets from ${ENV_FILE}...${NC}"
 
 # Inject secrets and capture the result
-if ! env_vars=$($OP_CMD inject -i "$ENV_FILE" 2>/dev/null); then
+if ! env_vars=$(${OP_CMD} inject -i "${ENV_FILE}" 2>/dev/null); then
 	echo_stderr "${RED}Error: Failed to inject secrets from 1Password${NC}"
 	echo_stderr "Check your env file and 1Password references"
 	exit 1
 fi
 
 # Remove comment lines (starting with #) and empty lines
-env_vars=$(echo "$env_vars" | sed '/^#/d' | sed '/^$/d')
+env_vars=$(echo "${env_vars}" | sed '/^#/d' | sed '/^$/d')
 
 # Show loaded variables if verbose mode is enabled
-if [[ "$VERBOSE" == "true" ]]; then
+if [[ "${VERBOSE}" == "true" ]]; then
 	echo_stdout -e "${GREEN}Loaded environment variables:${NC}"
-	echo "$env_vars" |
+	echo "${env_vars}" |
 		sed 's/=.*/=***/' |
 		sed 's/^/  /' >&2
 fi
@@ -187,8 +187,8 @@ echo_stdout -e "${GREEN}Executing command with injected secrets...${NC}"
 	# Export all the variables
 	key_value_pairs=()
 	while read -r line; do
-		key_value_pairs+=("$line")
-	done <<<"$env_vars"
+		key_value_pairs+=("${line}")
+	done <<<"${env_vars}"
 	export "${key_value_pairs[@]}"
 
 	# run the command

--- a/oprun
+++ b/oprun
@@ -37,7 +37,7 @@ win_exe_flag=0
 
 # Help message
 show_help() {
-  echo -e "
+	echo -e "
 ${BLUE}oprun${NC} - 1Password inject wrapper (WSL-friendly op run alternative)
 
 ${YELLOW}USAGE:${NC}
@@ -86,19 +86,19 @@ echo_stderr() {
 VERBOSE=false
 while [[ $# -gt 0 ]]; do
 	case $1 in
-		-h|--help)
+		-h | --help)
 			show_help
 			exit 0
 			;;
-		-e|--env-file)
+		-e | --env-file)
 			ENV_FILE="$2"
 			shift 2
 			;;
-		-v|--verbose)
+		-v | --verbose)
 			VERBOSE=true
 			shift
 			;;
-		-q|--quiet)
+		-q | --quiet)
 			quiet_flag=1
 			shift
 			;;
@@ -140,9 +140,9 @@ fi
 
 # Check if op CLI is available, with fallback to op.exe (for WSL)
 OP_CMD="op"
-if [[ $win_exe_flag -eq 1 ]] || ! command -v op &> /dev/null; then
+if [[ $win_exe_flag -eq 1 ]] || ! command -v op &>/dev/null; then
 	OP_CMD="op.exe"
-	if command -v "${OP_CMD}" &> /dev/null; then
+	if command -v "${OP_CMD}" &>/dev/null; then
 		echo_stdout "${YELLOW}Using Windows 1Password CLI (op.exe) from WSL${NC}"
 	else
 		echo_stderr "${RED}Error: 1Password CLI not found${NC}"
@@ -153,7 +153,7 @@ if [[ $win_exe_flag -eq 1 ]] || ! command -v op &> /dev/null; then
 fi
 
 # Check if user is signed in to 1Password
-if ! $OP_CMD account list &> /dev/null; then
+if ! $OP_CMD account list &>/dev/null; then
 	echo_stderr "${RED}Error: Not signed in to 1Password${NC}"
 	echo_stderr "Please run: $OP_CMD signin"
 	exit 1
@@ -174,9 +174,9 @@ env_vars=$(echo "$env_vars" | sed '/^#/d' | sed '/^$/d')
 # Show loaded variables if verbose mode is enabled
 if [[ "$VERBOSE" == "true" ]]; then
 	echo_stdout -e "${GREEN}Loaded environment variables:${NC}"
-	echo "$env_vars" \
-		| sed 's/=.*/=***/' \
-		| sed 's/^/  /' >&2
+	echo "$env_vars" |
+		sed 's/=.*/=***/' |
+		sed 's/^/  /' >&2
 fi
 
 echo_stdout -e "${GREEN}Executing command with injected secrets...${NC}"

--- a/oprun
+++ b/oprun
@@ -13,6 +13,7 @@
 #   oprun -h
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 # Default values
 ENV_FILE=".env.template"
@@ -139,10 +140,10 @@ if [[ ! -f "${ENV_FILE}" ]]; then
 fi
 
 # Check if op CLI is available, with fallback to op.exe (for WSL)
-OP_CMD="op"
+op_cmd_0="op"
 if [[ ${win_exe_flag} -eq 1 ]] || ! command -v op &>/dev/null; then
-  OP_CMD="op.exe"
-  if command -v "${OP_CMD}" &>/dev/null; then
+  op_cmd_0="op.exe"
+  if command -v "${op_cmd_0}" &>/dev/null; then
     echo_stdout "${YELLOW}Using Windows 1Password CLI (op.exe) from WSL${NC}"
   else
     echo_stderr "${RED}Error: 1Password CLI not found${NC}"
@@ -153,16 +154,16 @@ if [[ ${win_exe_flag} -eq 1 ]] || ! command -v op &>/dev/null; then
 fi
 
 # Check if user is signed in to 1Password
-if ! ${OP_CMD} account list &>/dev/null; then
+if ! "${op_cmd_0}" account list &>/dev/null; then
   echo_stderr "${RED}Error: Not signed in to 1Password${NC}"
-  echo_stderr "Please run: ${OP_CMD} signin"
+  echo_stderr "Please run: ${op_cmd_0} signin"
   exit 1
 fi
 
 echo_stdout "${BLUE}Loading secrets from ${ENV_FILE}...${NC}"
 
 # Inject secrets and capture the result
-if ! env_vars=$(${OP_CMD} inject -i "${ENV_FILE}" 2>/dev/null); then
+if ! env_vars=$("${op_cmd_0}" inject -i "${ENV_FILE}" 2>/dev/null); then
   echo_stderr "${RED}Error: Failed to inject secrets from 1Password${NC}"
   echo_stderr "Check your env file and 1Password references"
   exit 1

--- a/oprun
+++ b/oprun
@@ -19,17 +19,17 @@ ENV_FILE=".env.template"
 
 # Color codes for output (only if terminal supports it)
 if [[ -t 1 ]] && [[ "${TERM:-}" != "dumb" ]]; then
-	RED='\033[0;31m'
-	GREEN='\033[0;32m'
-	YELLOW='\033[1;33m'
-	BLUE='\033[0;34m'
-	NC='\033[0m' # No Color
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m' # No Color
 else
-	RED=''
-	GREEN=''
-	YELLOW=''
-	BLUE=''
-	NC=''
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  NC=''
 fi
 
 quiet_flag=0
@@ -37,7 +37,7 @@ win_exe_flag=0
 
 # Help message
 show_help() {
-	echo -e "
+  echo -e "
 ${BLUE}oprun${NC} - 1Password inject wrapper (WSL-friendly op run alternative)
 
 ${YELLOW}USAGE:${NC}
@@ -70,102 +70,102 @@ ${YELLOW}SETUP:${NC}
 }
 
 echo_stdout() {
-	(
-		if [[ ${quiet_flag:?} -eq 1 ]]; then
-			exec 1>&2
-		fi
-		echo -e "${1}"
-	)
+  (
+    if [[ ${quiet_flag:?} -eq 1 ]]; then
+      exec 1>&2
+    fi
+    echo -e "${1}"
+  )
 }
 
 echo_stderr() {
-	echo -e "${1}" >&2
+  echo -e "${1}" >&2
 }
 
 # Parse command line arguments
 VERBOSE=false
 while [[ $# -gt 0 ]]; do
-	case $1 in
-	-h | --help)
-		show_help
-		exit 0
-		;;
-	-e | --env-file)
-		ENV_FILE="$2"
-		shift 2
-		;;
-	-v | --verbose)
-		VERBOSE=true
-		shift
-		;;
-	-q | --quiet)
-		quiet_flag=1
-		shift
-		;;
-	--win-exe)
-		win_exe_flag=1
-		shift
-		;;
-	--)
-		shift
-		break
-		;;
-	-*)
-		echo_stderr "${RED}Error: Unknown option $1${NC}"
-		echo_stderr "Use -h or --help for usage information"
-		exit 1
-		;;
-	*)
-		# First non-option argument, assume it's the start of the command
-		break
-		;;
-	esac
+  case $1 in
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    -e | --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    -v | --verbose)
+      VERBOSE=true
+      shift
+      ;;
+    -q | --quiet)
+      quiet_flag=1
+      shift
+      ;;
+    --win-exe)
+      win_exe_flag=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo_stderr "${RED}Error: Unknown option $1${NC}"
+      echo_stderr "Use -h or --help for usage information"
+      exit 1
+      ;;
+    *)
+      # First non-option argument, assume it's the start of the command
+      break
+      ;;
+  esac
 done
 
 # Check if we have a command to run
 if [[ $# -eq 0 ]]; then
-	echo_stderr "${RED}Error: No command specified${NC}"
-	echo_stderr "Use -h or --help for usage information"
-	exit 1
+  echo_stderr "${RED}Error: No command specified${NC}"
+  echo_stderr "Use -h or --help for usage information"
+  exit 1
 fi
 
 # Check if env file exists
 if [[ ! -f "${ENV_FILE}" ]]; then
-	echo_stderr "${RED}Error: Env file '${ENV_FILE}' not found${NC}"
-	echo_stderr "${YELLOW}Create an env file with your 1Password secret references:${NC}"
-	echo_stderr 'DATABASE_URL="op://vault-name/item-name/field-name"'
-	echo_stderr 'API_KEY="op://vault-name/item-name/password"'
-	exit 1
+  echo_stderr "${RED}Error: Env file '${ENV_FILE}' not found${NC}"
+  echo_stderr "${YELLOW}Create an env file with your 1Password secret references:${NC}"
+  echo_stderr 'DATABASE_URL="op://vault-name/item-name/field-name"'
+  echo_stderr 'API_KEY="op://vault-name/item-name/password"'
+  exit 1
 fi
 
 # Check if op CLI is available, with fallback to op.exe (for WSL)
 OP_CMD="op"
 if [[ ${win_exe_flag} -eq 1 ]] || ! command -v op &>/dev/null; then
-	OP_CMD="op.exe"
-	if command -v "${OP_CMD}" &>/dev/null; then
-		echo_stdout "${YELLOW}Using Windows 1Password CLI (op.exe) from WSL${NC}"
-	else
-		echo_stderr "${RED}Error: 1Password CLI not found${NC}"
-		echo_stderr "Tried: 'op' and 'op.exe'"
-		echo_stderr "Please install 1Password CLI: https://developer.1password.com/docs/cli/get-started/"
-		exit 1
-	fi
+  OP_CMD="op.exe"
+  if command -v "${OP_CMD}" &>/dev/null; then
+    echo_stdout "${YELLOW}Using Windows 1Password CLI (op.exe) from WSL${NC}"
+  else
+    echo_stderr "${RED}Error: 1Password CLI not found${NC}"
+    echo_stderr "Tried: 'op' and 'op.exe'"
+    echo_stderr "Please install 1Password CLI: https://developer.1password.com/docs/cli/get-started/"
+    exit 1
+  fi
 fi
 
 # Check if user is signed in to 1Password
 if ! ${OP_CMD} account list &>/dev/null; then
-	echo_stderr "${RED}Error: Not signed in to 1Password${NC}"
-	echo_stderr "Please run: ${OP_CMD} signin"
-	exit 1
+  echo_stderr "${RED}Error: Not signed in to 1Password${NC}"
+  echo_stderr "Please run: ${OP_CMD} signin"
+  exit 1
 fi
 
 echo_stdout "${BLUE}Loading secrets from ${ENV_FILE}...${NC}"
 
 # Inject secrets and capture the result
 if ! env_vars=$(${OP_CMD} inject -i "${ENV_FILE}" 2>/dev/null); then
-	echo_stderr "${RED}Error: Failed to inject secrets from 1Password${NC}"
-	echo_stderr "Check your env file and 1Password references"
-	exit 1
+  echo_stderr "${RED}Error: Failed to inject secrets from 1Password${NC}"
+  echo_stderr "Check your env file and 1Password references"
+  exit 1
 fi
 
 # Remove comment lines (starting with #) and empty lines
@@ -173,10 +173,10 @@ env_vars=$(echo "${env_vars}" | sed '/^#/d' | sed '/^$/d')
 
 # Show loaded variables if verbose mode is enabled
 if [[ "${VERBOSE}" == "true" ]]; then
-	echo_stdout -e "${GREEN}Loaded environment variables:${NC}"
-	echo "${env_vars}" |
-		sed 's/=.*/=***/' |
-		sed 's/^/  /' >&2
+  echo_stdout -e "${GREEN}Loaded environment variables:${NC}"
+  echo "${env_vars}" \
+    | sed 's/=.*/=***/' \
+    | sed 's/^/  /' >&2
 fi
 
 echo_stdout -e "${GREEN}Executing command with injected secrets...${NC}"
@@ -184,13 +184,13 @@ echo_stdout -e "${GREEN}Executing command with injected secrets...${NC}"
 # Execute the command with injected environment variables
 # Using a subshell to avoid polluting the current environment
 (
-	# Export all the variables
-	key_value_pairs=()
-	while read -r line; do
-		key_value_pairs+=("${line}")
-	done <<<"${env_vars}"
-	export "${key_value_pairs[@]}"
+  # Export all the variables
+  key_value_pairs=()
+  while read -r line; do
+    key_value_pairs+=("${line}")
+  done <<<"${env_vars}"
+  export "${key_value_pairs[@]}"
 
-	# run the command
-	exec "$@"
+  # run the command
+  exec "$@"
 )


### PR DESCRIPTION
## Summary
- Add `mise.toml` to manage `shfmt` and `shellcheck` via mise.
- Define `lint:shfmt` and `lint:shellcheck` tasks targeting `oprun`.
- Add aggregate `lint` task with `depends = ["lint:*"]`.

## Test plan
- [ ] `mise install` succeeds and pins shfmt + shellcheck.
- [ ] `mise run lint:shfmt` reports formatting diff for `oprun`.
- [ ] `mise run lint:shellcheck` runs shellcheck on `oprun`.
- [ ] `mise run lint` triggers both `lint:*` tasks.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J2pZ4qJnmaAC7QKp4m2H6R)_