### PR TITLE
docs: recommend mise as the primary install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,7 @@ Before using `oprun`, you'll need:
 
 ## Installation
 
-### Option 1: Direct Download (Recommended)
-
-```bash
-# Download and install oprun to /usr/local/bin
-curl -sSL https://raw.githubusercontent.com/MykalMachon/oprun.sh/main/oprun -o /usr/local/bin/oprun
-chmod +x /usr/local/bin/oprun
-```
-
-### Option 2: mise (via the GitHub backend)
+### Option 1: mise (Recommended)
 
 If you use [mise](https://mise.jdx.dev/), you can install `oprun` from the
 [GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html):
@@ -50,6 +42,14 @@ Or in `mise.toml`:
 ```toml
 [tools]
 "github:pollenjp/oprun.sh" = "latest"
+```
+
+### Option 2: Direct Download
+
+```bash
+# Download and install oprun to /usr/local/bin
+curl -sSL https://raw.githubusercontent.com/MykalMachon/oprun.sh/main/oprun -o /usr/local/bin/oprun
+chmod +x /usr/local/bin/oprun
 ```
 
 ### Option 3: Manual Installation


### PR DESCRIPTION
## Summary

- Promote the mise GitHub backend installation to Option 1 (Recommended) in the README
- Demote the direct `curl` download to Option 2
- Manual installation remains as Option 3

mise gives users version pinning and easy upgrades out of the box, so it's a better default landing path than a raw `curl`.

## Test plan

- [ ] Render the README on GitHub and confirm the install options are reordered correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5mPPmmPZAf2XLDsdSnLfo)_