### PR TITLE
ci: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - name: Run release-please
         id: release


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token` の入力を `app-id` から `client-id` に変更
- 合わせてシークレット名を `RELEASE_PLEASE_APP_ID` → `RELEASE_PLEASE_APP_CLIENT_ID` にリネーム

参考: https://github.com/actions/create-github-app-token

## Test plan

- [ ] リポジトリの Secrets に `RELEASE_PLEASE_APP_CLIENT_ID` を新規追加（GitHub App の Client ID）
- [ ] 古い `RELEASE_PLEASE_APP_ID` シークレットを削除（任意）
- [ ] release ワークフローを実行してトークン生成が成功することを確認

https://claude.ai/code/session_01K54EHyLAerwfQpkh5H5257

---
_Generated by [Claude Code](https://claude.ai/code/session_01K54EHyLAerwfQpkh5H5257)_